### PR TITLE
New task to get the current deployed version of an application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ deploy:
   provider: releases
   api_key:
     secure: aoVXZyLOBmB4Q2lLKLaqEN8zcqN3K3/3agRBA1znM1PLeqXSE3CwQe6sHkX6BrfMoDDtjqeepDMgJ9TsqJFq+lPY+HuVFzOqGlrWlIZHBUKI3hmfjgM/61CkdK2eBO42Ym4tqCQ4L1Tp42fcrB6M/a/0TGI5ENW2bJk8+ofRT8M=
-  file: build/libs/xlr-xldeploy-plugin-2.0.1.jar
+  file: build/libs/xlr-xldeploy-plugin-2.0.2.jar
   skip_cleanup: true
   on:
     all_branches: true

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ This plugin (2.x.x+) requires XLR 4.8
   * `stripApplications` - Whether to strip "Applications/" from the beginning of the returned package ID
   * `packageId` - Return value with the latest package ID
 
++ Get Last Version Deployed 
+  * `server` - Server to query
+  * `username` - Override username
+  * `password` - Override password
+  * `environmentId` - ID of the environment to check the application version on
+  * `applicationName` - Name of the applicaiton in the environment to get the current version of
+returned package ID
+  * `applicationId` - Return value with the current application ID
+
+
 + Create CI
   * `server` - Server to query
   * `username` - Override username

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.github.hierynomus.license" version "0.11.0"
 }
 
-version="2.0.1"
+version="2.0.2"
 
 apply plugin: "com.github.hierynomus.license"
 apply plugin: 'java'

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -63,6 +63,14 @@
         <property name="packageId" category="output" label="Package ID" />
     </type>
 
+    <type type="xldeploy.GetLastVersionDeployedTask" extends="xldeploy.Task" description="Finds the latest version of the Package deployed in XL Deploy">
+        <property name="scriptLocation" default="xldeploy/getLatestDeployedTask.py" hidden="true" />
+        <property name="environmentId" category="input" label="Environment ID" required="true" />
+        <property name="applicationName" category="input" label="Application Name" required="true" />
+
+        <property name="applicationId" category="output" label="Application ID" />
+    </type>
+
     <type type="xldeploy.CreateCI" extends="xlrelease.PythonScript" label="Create CI" description="Creates a CI and optionally adds it to an environment">
         <property name="scriptLocation" default="xldeploy/createCITask.py" hidden="true" />
         <property name="xldeployServer" category="input" label="Server" referenced-type="xldeploy.Server" kind="ci"/>

--- a/src/main/resources/xldeploy/XLDeployClient.py
+++ b/src/main/resources/xldeploy/XLDeployClient.py
@@ -232,6 +232,17 @@ class XLDeployClient(object):
             latest_package = items[-1].attrib['ref']
         return latest_package
 
+    def get_latest_deployed_version(self, environment_id, applicationName):
+        query_task = "/deployit/repository/ci/%s/%s" % (environment_id, applicationName)
+        query_task_response = self.http_request.get(query_task, contentType='application/xml')
+        root = ET.fromstring(query_task_response.getResponse())
+        items = root.findall('version')
+        latest_package = ''
+        for item in items:
+             latest_package = item.attrib['ref']
+        # End for
+        return latest_package
+
     def check_CI_exist(self, ciId):
         queryTask = "/deployit/repository/exists/%s" % ciId
         queryTask_response = self.http_request.get(queryTask, contentType='application/xml')

--- a/src/main/resources/xldeploy/getLatestDeployedTask.py
+++ b/src/main/resources/xldeploy/getLatestDeployedTask.py
@@ -1,0 +1,12 @@
+# THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS
+# FOR A PARTICULAR PURPOSE. THIS CODE AND INFORMATION ARE NOT SUPPORTED BY XEBIALABS.
+#
+
+from xldeploy.XLDeployClientUtil import XLDeployClientUtil
+
+
+xld_client = XLDeployClientUtil.createXLDeployClient(xldeployServer, username, password)
+
+applicationId = xld_client.get_latest_deployed_version(environmentId, applicationName)
+


### PR DESCRIPTION
Added a new task to get the applicationId of an application that is deployed in an environment.  Useful if you need to roll back a change in XLD
