### PR TITLE
Added boolean property cancelOnError on Deploy and Undeploy tasks.

### DIFF
--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -32,9 +32,10 @@
         <property name="orchestrators" category="input" label="Orchestrators" default="" required="false" />
         <property name="deployedApplicationProperties" category="input" default="" required="false" description="A dictionary with key value pairs" />
         <property name="deployedProperties" category="input" default="" required="false" description="A dictionary with key value pairs" />
-        <property name="rollbackOnError" category="input" kind="boolean" />
-        <property name="failOnPause" category="input" kind="boolean" default="true" />
-        <property name="displayStepLogs" category="input" kind="boolean" default="true" />
+        <property name="rollbackOnError" category="input" kind="boolean" required="false" description="Perform rollback in XL Deploy if the task fails."/>
+        <property name="cancelOnError" category="input" kind="boolean" required="false" label="Cancel If Not Rollbacking" default="true" description="Cancel the task in XL Deploy if the tasks fails and Rollback On Error is not selected."/>
+        <property name="failOnPause" category="input" kind="boolean" required="false" default="true" />
+        <property name="displayStepLogs" category="input" kind="boolean" required="false" default="true" />
     </type>
 
     <type type="xldeploy.UndeployTask" extends="xldeploy.TaskRunningTask" description="Executes an undeployment in XL Deploy">
@@ -45,8 +46,9 @@
 
         <property name="orchestrators" category="input" label="Orchestrators" default="" required="false" />
         <property name="deployedApplicationProperties" category="input" default="" required="false" description="A dictionary with key value pairs" />
-        <property name="rollbackOnError" category="input" kind="boolean" />
-        <property name="failOnPause" category="input" kind="boolean" default="true" />
+        <property name="rollbackOnError" category="input" kind="boolean" required="false" description="Perform rollback in XL Deploy if the task fails."/>
+        <property name="cancelOnError" category="input" kind="boolean" required="false" label="Cancel If Not Rollbacking" default="true" description="Cancel the task in XL Deploy if the tasks fails and Rollback On Error is not selected."/>
+        <property name="failOnPause" category="input" kind="boolean" required="false" default="true" />
 
     </type>
 

--- a/src/main/resources/xldeploy/deployTask.py
+++ b/src/main/resources/xldeploy/deployTask.py
@@ -54,8 +54,10 @@ if taskState in ('FAILED', 'STOPPED'):
         rollBackTaskId = xldClient.deployment_rollback(taskId)
         taskState = xldClient.invoke_task_and_wait_for_result(rollBackTaskId, pollingInterval, numberOfPollingTrials, continueIfStepFails, numberOfContinueRetrials)
         xldClient.archive_task(rollBackTaskId)
-    else:
-        print "Task failed, rollback not enabled. \n"
+    elif cancelOnError:
+        print "Task failed; cancelling task. \n"
         xldClient.cancel_task(taskId)
+    else:
+        print "Task failed; leaving as-is in XL Deploy. \n"
 
 sys.exit(1)

--- a/src/main/resources/xldeploy/undeployTask.py
+++ b/src/main/resources/xldeploy/undeployTask.py
@@ -47,6 +47,9 @@ if rollbackOnError and task_state in ('FAILED', 'STOPPED'):
     xld_client.archive_task(rollback_task_id)
     sys.exit(1)
 elif task_state in ('FAILED', 'STOPPED'):
-    print "Task failed, rollback not enabled. \n"
-    xld_client.cancel_task(task_id)
+    if cancelOnError:
+        print "Task failed; cancelling task. \n"
+        xld_client.cancel_task(task_id)
+    else:
+        print "Task failed; leaving as-is in XL Deploy. \n"
     sys.exit(1)


### PR DESCRIPTION
Needed for Paychex: they don't want rollback or cancel on failure, but being able to finish the task manually.
