### PR TITLE
Existence Check Added to Get requests

### DIFF
--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -81,6 +81,7 @@
         <property name="scriptLocation" default="xldeploy/getLatestVersionTask.py" hidden="true" />
         <property name="applicationId" category="input" label="Application ID" required="true" />
         <property name="stripApplications" category="input" kind="boolean" />
+        <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail" description="If True, the Task will fail if the CI doesn't exist" />
 
         <property name="packageId" category="output" label="Package ID" />
     </type>
@@ -89,6 +90,7 @@
         <property name="scriptLocation" default="xldeploy/getAllVersionsTask.py" hidden="true" />
         <property name="applicationId" category="input" label="Application ID" required="true" />
         <!-- <property name="stripApplications" category="input" kind="boolean" /> -->
+        <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail" description="If True, the Task will fail if the CI doesn't exist" />
 
         <property name="packageIds" category="output" kind="list_of_string" label="Package IDs" />
     </type>

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -81,7 +81,7 @@
         <property name="scriptLocation" default="xldeploy/getLatestVersionTask.py" hidden="true" />
         <property name="applicationId" category="input" label="Application ID" required="true" />
         <property name="stripApplications" category="input" kind="boolean" />
-        <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail" description="If True, the Task will fail if the CI doesn't exist" />
+        <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail" description="If True, the Task will fail if the CI doesn't exist" default="false"/>
 
         <property name="packageId" category="output" label="Package ID" />
     </type>
@@ -90,7 +90,7 @@
         <property name="scriptLocation" default="xldeploy/getAllVersionsTask.py" hidden="true" />
         <property name="applicationId" category="input" label="Application ID" required="true" />
         <!-- <property name="stripApplications" category="input" kind="boolean" /> -->
-        <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail" description="If True, the Task will fail if the CI doesn't exist" />
+        <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail" description="If True, the Task will fail if the CI doesn't exist" default="false" />
 
         <property name="packageIds" category="output" kind="list_of_string" label="Package IDs" />
     </type>

--- a/src/main/resources/xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xldeploy/getAllVersionsTask.py
@@ -7,16 +7,19 @@
 from xldeploy.XLDeployClientUtil import XLDeployClientUtil
 
 xld_client = XLDeployClientUtil.create_xldeploy_client(xldeployServer, username, password)
-
+try:
+	throwOnFail
+except:
+	throwOnFail = False
 try:
     response = xld_client.check_ci_exist(applicationId)
 except:
 	response = False
 
-if not response:
+if throwOnFail and not response:
 	raise Exception(applicationId + " does not exist")
 
 packageIds = xld_client.get_all_package_version(applicationId)
 
-if len(packageIds) == 0:
+if throwOnFail and len(packageIds) == 0:
 	raise Exception(applicationId + " exists but has no versions")

--- a/src/main/resources/xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xldeploy/getAllVersionsTask.py
@@ -7,10 +7,7 @@
 from xldeploy.XLDeployClientUtil import XLDeployClientUtil
 
 xld_client = XLDeployClientUtil.create_xldeploy_client(xldeployServer, username, password)
-try:
-	throwOnFail
-except:
-	throwOnFail = False
+
 try:
     response = xld_client.check_ci_exist(applicationId)
 except:

--- a/src/main/resources/xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xldeploy/getAllVersionsTask.py
@@ -17,3 +17,6 @@ if not response:
 	raise Exception(applicationId + " does not exist")
 
 packageIds = xld_client.get_all_package_version(applicationId)
+
+if len(packageIds) == 0:
+	raise Exception(applicationId + " exists but has no versions")

--- a/src/main/resources/xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xldeploy/getAllVersionsTask.py
@@ -6,7 +6,14 @@
 
 from xldeploy.XLDeployClientUtil import XLDeployClientUtil
 
-
 xld_client = XLDeployClientUtil.create_xldeploy_client(xldeployServer, username, password)
+
+try:
+    response = xld_client.check_ci_exist(applicationId)
+except:
+	response = False
+
+if not response:
+	raise Exception(applicationId + " does not exist")
 
 packageIds = xld_client.get_all_package_version(applicationId)

--- a/src/main/resources/xldeploy/getLatestVersionTask.py
+++ b/src/main/resources/xldeploy/getLatestVersionTask.py
@@ -9,11 +9,16 @@ from xldeploy.XLDeployClientUtil import XLDeployClientUtil
 xld_client = XLDeployClientUtil.create_xldeploy_client(xldeployServer, username, password)
 
 try:
+	throwOnFail
+except:
+	throwOnFail = False
+	
+try:
     response = xld_client.check_ci_exist(applicationId)
 except:
 	response = False
 
-if not response:
+if throwOnFail and not response:
 	raise Exception(applicationId + " does not exist")
 
 packageId = xld_client.get_latest_package_version(applicationId)
@@ -21,5 +26,5 @@ packageId = xld_client.get_latest_package_version(applicationId)
 if stripApplications:
     packageId = packageId.partition('/')[2]
 
-if packageId == "":
+if throwOnFail and packageId == "":
 	raise Exception(applicationId + " exists but has no versions")

--- a/src/main/resources/xldeploy/getLatestVersionTask.py
+++ b/src/main/resources/xldeploy/getLatestVersionTask.py
@@ -6,8 +6,15 @@
 
 from xldeploy.XLDeployClientUtil import XLDeployClientUtil
 
-
 xld_client = XLDeployClientUtil.create_xldeploy_client(xldeployServer, username, password)
+
+try:
+    response = xld_client.check_ci_exist(applicationId)
+except:
+	response = False
+
+if not response:
+	raise Exception(applicationId + " does not exist")
 
 packageId = xld_client.get_latest_package_version(applicationId)
 

--- a/src/main/resources/xldeploy/getLatestVersionTask.py
+++ b/src/main/resources/xldeploy/getLatestVersionTask.py
@@ -7,11 +7,6 @@
 from xldeploy.XLDeployClientUtil import XLDeployClientUtil
 
 xld_client = XLDeployClientUtil.create_xldeploy_client(xldeployServer, username, password)
-
-try:
-	throwOnFail
-except:
-	throwOnFail = False
 	
 try:
     response = xld_client.check_ci_exist(applicationId)

--- a/src/main/resources/xldeploy/getLatestVersionTask.py
+++ b/src/main/resources/xldeploy/getLatestVersionTask.py
@@ -20,3 +20,6 @@ packageId = xld_client.get_latest_package_version(applicationId)
 
 if stripApplications:
     packageId = packageId.partition('/')[2]
+
+if packageId == "":
+	raise Exception(applicationId + " exists but has no versions")


### PR DESCRIPTION
getAllVersions and getLatestVersion tasks were completing in XL Release, even if the CI didn't exist. That meant downstream tasks were failing because an empty string was being passed to them. 

The pre-existing workaround was to do a separate doesCIExist task for every single Get, which seemed a lot of work considering we just want to catch mistakes. 

Added in a second check to ensure that the Application has at least one child package. This means that tese two tasks should now always return something or fail, rather than sometimes returning an empty string. 