### PR TITLE
Fixed Invalid Credentials Bug

### DIFF
--- a/src/main/resources/xlr_xldeploy/undeployTask.py
+++ b/src/main/resources/xlr_xldeploy/undeployTask.py
@@ -18,6 +18,11 @@ xld_client = XLDeployClientUtil.create_xldeploy_client(xldeployServer, username,
 deployment = None
 deployment_package = "{0}/{1}".format(environment, deployedApplication)
 print "* deployment package is {0}".format(deployment_package)
+
+if not xld_client.check_ci_exist(environment):
+    print("\n* Check your username and password and ensure that your ID starts with Environments/.")
+    raise Exception("\n* [%s] either does not exist or you do not have the correct permissions to read it." % (environment))
+
 if xld_client.deployment_exists2(deployment_package):
     print "Undeploying [%s] from environment [%s] \n" % (deployment_package, environment)
     deployment = xld_client.deployment_prepare_undeploy("%s/%s" % (environment, deployedApplication), orchestrators,


### PR DESCRIPTION
Existing implementation completed task if xld_client.deployment_exists2(deployment_package) returned false. 
This function will return false if Invalid credentials are passed to the xld_client. Checking the existence of the Environment (and throwing if it does not exist) ensures that the credentials are valid.