### PR TITLE
Get All Versions improvements

### DIFF
--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -134,8 +134,9 @@
         <property name="scriptLocation" default="xlr_xldeploy/getAllVersionsTask.py" hidden="true"/>
         <property name="applicationId" category="input" label="Application ID" required="true"/>
         <!-- <property name="stripApplications" category="input" kind="boolean" /> -->
-        <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail"
-                  description="If True, the Task will fail if the CI doesn't exist" default="false"/>
+        <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail" description="If True, the Task will fail if the CI doesn't exist" default="false"/>
+        <property name="recurse" category="input" kind="boolean" label="Recursive" description="If True, recurses through child directories" default="false"/>
+        <property name="target_list_box" category="input" kind="string" label="List Box" description="If you wish to populate a List Box, provide the existing release variable name here (without ${ or })"/>
 
         <property name="packageIds" category="output" kind="list_of_string" label="Package IDs"/>
     </type>

--- a/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
@@ -24,3 +24,8 @@ packageIds = xld_client.get_all_package_version(applicationId)
 
 if throwOnFail and len(packageIds) == 0:
 	raise Exception(applicationId + " exists but has no versions")
+
+if target_list_box:
+    target = getCurrentRelease().variablesByKeys[target_list_box]
+    target.valueProvider.setValues(packageIds)
+    releaseApi.updateVariable(target)


### PR DESCRIPTION
2 changes to Get All Versions

1. Recursion. Change to the root Client. Defaults to off (mimics current behaviour) but if active then it will recurse through directories. This covers situations where some foldershave a mixture of CIs and core.Directory objects. 

2. ListBox population. Currently the app can populate a List... but not a ListBox. This is a simple addition that prevents having a second script to simply populate a user input List box. 