### PR TITLE
Use the default parameter value for missing parameters

### DIFF
--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright 2017 XEBIALABS
+    Copyright 2018 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/web/include/XLDVersionsTile/grid/application.html
+++ b/src/main/resources/web/include/XLDVersionsTile/grid/application.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2017 XEBIALABS
+    Copyright 2018 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/web/include/XLDVersionsTile/grid/name-filter-template.html
+++ b/src/main/resources/web/include/XLDVersionsTile/grid/name-filter-template.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2017 XEBIALABS
+    Copyright 2018 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/web/include/XLDVersionsTile/grid/version.html
+++ b/src/main/resources/web/include/XLDVersionsTile/grid/version.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2017 XEBIALABS
+    Copyright 2018 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/web/include/XLDVersionsTile/js/xld-versions-tile.js
+++ b/src/main/resources/web/include/XLDVersionsTile/js/xld-versions-tile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 XEBIALABS
+ * Copyright 2018 XEBIALABS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *

--- a/src/main/resources/web/include/XLDVersionsTile/xld-versions-tile-view.html
+++ b/src/main/resources/web/include/XLDVersionsTile/xld-versions-tile-view.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2017 XEBIALABS
+    Copyright 2018 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/xl-ui-plugin.xml
+++ b/src/main/resources/xl-ui-plugin.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2017 XEBIALABS
+    Copyright 2018 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/xlr_xldeploy/AddCITag.py
+++ b/src/main/resources/xlr_xldeploy/AddCITag.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/GetCITags.py
+++ b/src/main/resources/xlr_xldeploy/GetCITags.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/LocalCLI.py
+++ b/src/main/resources/xlr_xldeploy/LocalCLI.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/SetCITags.py
+++ b/src/main/resources/xlr_xldeploy/SetCITags.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/XLDVersionsTile.py
+++ b/src/main/resources/xlr_xldeploy/XLDVersionsTile.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/XLDeployClient.py
+++ b/src/main/resources/xlr_xldeploy/XLDeployClient.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/XLDeployClient.py
+++ b/src/main/resources/xlr_xldeploy/XLDeployClient.py
@@ -115,16 +115,16 @@ class XLDeployClient(object):
     def create_client(http_connection, username=None, password=None):
         return XLDeployClient(http_connection, username, password)
 
-    def get_parameter_names(self, parameter_type_id):
+    def get_parameters(self, parameter_type_id):
         metadata_url = "/deployit/metadata/type/%s" % (parameter_type_id)
         metadata_response = self.http_request.get(metadata_url, contentType='application/xml')
         root = ET.fromstring(metadata_response.getResponse())
         params = root.find("property-descriptors")
-        parameter_names = []
+        parameters = []
         if params:
             for child in params:
-                parameter_names.append({'name': child.get("name"), 'default': child.get('default')})
-        return parameter_names
+                parameters.append({'name': child.get("name"), 'default': child.get('default')})
+        return parameters
 
     def prepare_control_task(self, control_task_name, target_ci_id, parameters=None):
         prepare_control_task_url = "/deployit/control/prepare/%s/%s" % (control_task_name, target_ci_id)
@@ -137,9 +137,9 @@ class XLDeployClient(object):
         if parameters:
             parameter_type_id = get_parameter_type_name(root)
             if parameter_type_id:
-                parameter_names = self.get_parameter_names(parameter_type_id)
-                for parameterName in parameter_names:
-                    add_parameter(root, parameter_type_id, parameterName, parameters)
+                parameters_definition = self.get_parameters(parameter_type_id)
+                for parameter in parameters_definition:
+                    add_parameter(root, parameter_type_id, parameter, parameters)
         invoke_response = self.http_request.post('/deployit/control', ET.tostring(root), contentType='application/xml')
         check_response(invoke_response, "Failed to create control task [%s]. Server return [%s], with content [%s]" % (
             target_ci_id, invoke_response.status, invoke_response.response))

--- a/src/main/resources/xlr_xldeploy/XLDeployClient.py
+++ b/src/main/resources/xlr_xldeploy/XLDeployClient.py
@@ -30,14 +30,16 @@ def get_parameter_type_name(root):
             return child.tag
 
 
-def add_parameter(root, parameter_type_id, parameter_name, parameters):
+def add_parameter(root, parameter_type_id, parameter, parameters):
     params = root.find("parameters")
     if params and parameters:
         property_dict = dict(ast.literal_eval(parameters))
         for child in params:
             if child.tag == parameter_type_id:
-                param = ET.SubElement(child, parameter_name)
-                param.text = str(property_dict[parameter_name])
+                name = parameter['name']
+                default = parameter['default']
+                param = ET.SubElement(child, name)
+                param.text = str(property_dict.get(name, default))
 
 
 def set_deployed_application_properties(deployment_xml, deployed_application_properties):
@@ -121,7 +123,7 @@ class XLDeployClient(object):
         parameter_names = []
         if params:
             for child in params:
-                parameter_names.append(child.get("name"))
+                parameter_names.append({'name': child.get("name"), 'default': child.get('default')})
         return parameter_names
 
     def prepare_control_task(self, control_task_name, target_ci_id, parameters=None):

--- a/src/main/resources/xlr_xldeploy/XLDeployClientUtil.py
+++ b/src/main/resources/xlr_xldeploy/XLDeployClientUtil.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/__init__.py
+++ b/src/main/resources/xlr_xldeploy/__init__.py
@@ -1,9 +1,11 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
 #

--- a/src/main/resources/xlr_xldeploy/cli.py
+++ b/src/main/resources/xlr_xldeploy/cli.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/cliFile.py
+++ b/src/main/resources/xlr_xldeploy/cliFile.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/cliUrl.py
+++ b/src/main/resources/xlr_xldeploy/cliUrl.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/controlTask.py
+++ b/src/main/resources/xlr_xldeploy/controlTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/createCITask.py
+++ b/src/main/resources/xlr_xldeploy/createCITask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/createFolder.py
+++ b/src/main/resources/xlr_xldeploy/createFolder.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/deleteCITask.py
+++ b/src/main/resources/xlr_xldeploy/deleteCITask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/deleteInfrastructureTask.py
+++ b/src/main/resources/xlr_xldeploy/deleteInfrastructureTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/deployTask.py
+++ b/src/main/resources/xlr_xldeploy/deployTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/doesCIExistTask.py
+++ b/src/main/resources/xlr_xldeploy/doesCIExistTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/getCITask.py
+++ b/src/main/resources/xlr_xldeploy/getCITask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/getLatestDeployedTask.py
+++ b/src/main/resources/xlr_xldeploy/getLatestDeployedTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/getLatestVersionTask.py
+++ b/src/main/resources/xlr_xldeploy/getLatestVersionTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/importTask.py
+++ b/src/main/resources/xlr_xldeploy/importTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/migrateTask.py
+++ b/src/main/resources/xlr_xldeploy/migrateTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/undeployTask.py
+++ b/src/main/resources/xlr_xldeploy/undeployTask.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/xlr_xldeploy/updateCIProperty.py
+++ b/src/main/resources/xlr_xldeploy/updateCIProperty.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/test/resources/docker/initialize/data/create-ci-demo-data.json
+++ b/src/test/resources/docker/initialize/data/create-ci-demo-data.json
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 XEBIALABS
+ * Copyright 2018 XEBIALABS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *

--- a/src/test/resources/docker/initialize/data/server-configs.json
+++ b/src/test/resources/docker/initialize/data/server-configs.json
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 XEBIALABS
+ * Copyright 2018 XEBIALABS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *

--- a/src/test/resources/docker/initialize/initialize_data.sh
+++ b/src/test/resources/docker/initialize/initialize_data.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2017 XEBIALABS
+# Copyright 2018 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #


### PR DESCRIPTION
We have a control task that have optional parameter. When starting the control task from XLDeploy, the default value is filled automatically.
When starting the same control task from the 'XL Deploy: Control task extended', the XLDeployClient is fetching the metadata of the control task to fill the parameters but does not use the default value configured by XLDeploy.

This pull request use the default value for a parameter if it is not provided.