### PR TITLE
Add stripApplication parameter to getAllVersions Task

### DIFF
--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -133,7 +133,7 @@
           description="Finds all Deployment Package versions for an Application in XL Deploy">
         <property name="scriptLocation" default="xlr_xldeploy/getAllVersionsTask.py" hidden="true"/>
         <property name="applicationId" category="input" label="Application ID" required="true"/>
-        <!-- <property name="stripApplications" category="input" kind="boolean" /> -->
+        <property name="stripApplications" category="input" kind="boolean" />
         <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail"
                   description="If True, the Task will fail if the CI doesn't exist" default="false"/>
 

--- a/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
@@ -23,11 +23,7 @@ if throwOnFail and not response:
 packageIds = xld_client.get_all_package_version(applicationId)
 
 if stripApplications:
-    packageIdsTmp = list()
-    for version in packageIds:
-        version = version.partition('/')[2]
-        packageIdsTmp.append(version)
-    packageIds = packageIdsTmp
+    packageIds = [version.partition('/')[2] for version in packageIds]
 
 if throwOnFail and len(packageIds) == 0:
 	raise Exception(applicationId + " exists but has no versions")

--- a/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
@@ -22,5 +22,12 @@ if throwOnFail and not response:
 
 packageIds = xld_client.get_all_package_version(applicationId)
 
+if stripApplications:
+    packageIdsTmp = list()
+    for version in packageIds:
+        version = version.partition('/')[2]
+        packageIdsTmp.append(version)
+    packageIds = packageIdsTmp
+
 if throwOnFail and len(packageIds) == 0:
 	raise Exception(applicationId + " exists but has no versions")


### PR DESCRIPTION
As it is already done to getLatestVersion Task
The aim is to delete the string "Applications/" in all the strings.
Otherwise we can't use one of these values as an input to an XL Deploy task, because we would have "Applications/Applications/......" and this won't work.