### PR TITLE
Add Get all environments task

### DIFF
--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -133,25 +133,27 @@
           description="Finds all Deployment Package versions for an Application in XL Deploy">
         <property name="scriptLocation" default="xlr_xldeploy/getAllVersionsTask.py" hidden="true"/>
         <property name="applicationId" category="input" label="Application ID" required="true"/>
-        <property name="stripApplications" category="input" kind="boolean" />
+        <property name="stripApplications" category="input" kind="boolean" description="Remove the 'Applications' string returned"/>
+        <property name="getChild" category="input" label="Get Childs" kind="boolean" description="Search for packages recursively"/>
+        <property name="deploymentPackage" category="input" label="Only Deployment Packages" kind="boolean" description="Return only Deployment Packages"/>
         <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail"
                   description="If True, the Task will fail if the CI doesn't exist" default="false"/>
 
         <property name="packageIds" category="output" kind="list_of_string" label="Package IDs"/>
     </type>
-    
+	
     <type type="xldeploy.GetAllEnvsTask" label="XL Deploy: Get all environments" extends="xldeploy.Task"
           description="Finds all Environments available in XL Deploy">
         <property name="scriptLocation" default="xlr_xldeploy/getAllEnvsTask.py" hidden="true"/>
-        <property name="environmentId" category="input" label="Environment ID" required="true"/>
-        <property name="stripEnvironments" category="input" kind="boolean" />
-        <property name="getChild" category="input" label="Get Childs" kind="boolean" />
+        <property name="environmentId" category="input" label="Environment ID" required="true" />
+        <property name="stripEnvironments" category="input" kind="boolean" description="Remove the 'Environments' string returned"/>
+        <property name="getChild" category="input" label="Get Childs" kind="boolean" description="Search for environments recursively"/>
         <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail"
                   description="If True, the Task will fail if the CI doesn't exist" default="false"/>
 
         <property name="environmentIds" category="output" kind="list_of_string" label="Environment IDs"/>
     </type>
-
+    
     <type type="xldeploy.GetCITask" extends="xldeploy.Task" label="XL Deploy: Get CI" description="Gets a CI XML from XL Deploy">
         <property name="scriptLocation" default="xlr_xldeploy/getCITask.py" hidden="true" />
         <property name="ciID" category="input" label="CI ID" required="true"/>

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -135,6 +135,7 @@
         <property name="applicationId" category="input" label="Application ID" required="true"/>
         <property name="stripApplications" category="input" kind="boolean" description="Remove the 'Applications' string returned"/>
         <property name="getChild" category="input" label="Get Childs" kind="boolean" description="Search for packages recursively"/>
+        <property name="applicationPackage" category="input" label="Only Application Packages" kind="boolean" description="Return only Application Packages"/>
         <property name="deploymentPackage" category="input" label="Only Deployment Packages" kind="boolean" description="Return only Deployment Packages"/>
         <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail"
                   description="If True, the Task will fail if the CI doesn't exist" default="false"/>

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -140,6 +140,18 @@
         <property name="packageIds" category="output" kind="list_of_string" label="Package IDs"/>
     </type>
     
+    <type type="xldeploy.GetAllEnvsTask" label="XL Deploy: Get all environments" extends="xldeploy.Task"
+          description="Finds all Environments available in XL Deploy">
+        <property name="scriptLocation" default="xlr_xldeploy/getAllEnvsTask.py" hidden="true"/>
+        <property name="environmentId" category="input" label="Environment ID" required="true"/>
+        <property name="stripEnvironments" category="input" kind="boolean" />
+        <property name="getChild" category="input" label="Get Childs" kind="boolean" />
+        <property name="throwOnFail" category="input" kind="boolean" label="Throw on Fail"
+                  description="If True, the Task will fail if the CI doesn't exist" default="false"/>
+
+        <property name="environmentIds" category="output" kind="list_of_string" label="Environment IDs"/>
+    </type>
+
     <type type="xldeploy.GetCITask" extends="xldeploy.Task" label="XL Deploy: Get CI" description="Gets a CI XML from XL Deploy">
         <property name="scriptLocation" default="xlr_xldeploy/getCITask.py" hidden="true" />
         <property name="ciID" category="input" label="CI ID" required="true"/>

--- a/src/main/resources/xlr_xldeploy/XLDeployClient.py
+++ b/src/main/resources/xlr_xldeploy/XLDeployClient.py
@@ -316,16 +316,28 @@ class XLDeployClient(object):
         all_dir = list()
         for item in items:
             all_dir.append(item.attrib['ref'])
+        query_task = "/deployit/repository/query?parent=%s&type=udm.Application&resultsPerPage=-1" % directory_id
+        query_task_response = self.http_request.get(query_task, contentType='application/xml')
+        root = ET.fromstring(query_task_response.getResponse())
+        items = root.findall('ci')
+        for item in items:
+            all_dir.append(item.attrib['ref'])
         return all_dir
 
-    def get_all_package_version(self, application_id):
+    def get_all_package_version(self, application_id, getChild, deploymentPackage):
         query_task = "/deployit/repository/query?parent=%s&resultsPerPage=-1" % application_id
+        if deploymentPackage:
+            query_task = "/deployit/repository/query?parent=%s&type=udm.DeploymentPackage&resultsPerPage=-1" % application_id
         query_task_response = self.http_request.get(query_task, contentType='application/xml')
         root = ET.fromstring(query_task_response.getResponse())
         items = root.findall('ci')
         all_package = list()
         for item in items:
             all_package.append(item.attrib['ref'])
+        if getChild:
+            all_dir = self.get_all_directory(application_id)
+            for curr_dir in all_dir:
+                all_package.extend(self.get_all_package_version(curr_dir, getChild, deploymentPackage))
         return all_package
 
     def get_all_environment(self, environment_id, getChild):

--- a/src/main/resources/xlr_xldeploy/XLDeployClient.py
+++ b/src/main/resources/xlr_xldeploy/XLDeployClient.py
@@ -299,7 +299,7 @@ class XLDeployClient(object):
             response.status, response.response))
 
     def get_latest_package_version(self, application_id):
-        query_task = "/deployit/repository/query?parent=%s&resultsPerPage=-1" % application_id
+        query_task = "/deployit/repository/query?parent=%s" % application_id
         query_task_response = self.http_request.get(query_task, contentType='application/xml')
         root = ET.fromstring(query_task_response.getResponse())
         items = root.findall('ci')
@@ -309,14 +309,14 @@ class XLDeployClient(object):
         return latest_package
 
     def get_all_directory(self, directory_id):
-        query_task = "/deployit/repository/query?parent=%s&type=core.Directory&resultsPerPage=-1" % directory_id
+        query_task = "/deployit/repository/query?parent=%s&type=core.Directory" % directory_id
         query_task_response = self.http_request.get(query_task, contentType='application/xml')
         root = ET.fromstring(query_task_response.getResponse())
         items = root.findall('ci')
         all_dir = list()
         for item in items:
             all_dir.append(item.attrib['ref'])
-        query_task = "/deployit/repository/query?parent=%s&type=udm.Application&resultsPerPage=-1" % directory_id
+        query_task = "/deployit/repository/query?parent=%s&type=udm.Application" % directory_id
         query_task_response = self.http_request.get(query_task, contentType='application/xml')
         root = ET.fromstring(query_task_response.getResponse())
         items = root.findall('ci')
@@ -324,10 +324,12 @@ class XLDeployClient(object):
             all_dir.append(item.attrib['ref'])
         return all_dir
 
-    def get_all_package_version(self, application_id, getChild, deploymentPackage):
-        query_task = "/deployit/repository/query?parent=%s&resultsPerPage=-1" % application_id
+    def get_all_package_version(self, application_id, getChild, deploymentPackage, applicationPackage):
+        query_task = "/deployit/repository/query?parent=%s" % application_id
         if deploymentPackage:
-            query_task = "/deployit/repository/query?parent=%s&type=udm.DeploymentPackage&resultsPerPage=-1" % application_id
+            query_task = "/deployit/repository/query?parent=%s&type=udm.DeploymentPackage" % application_id
+        if applicationPackage:
+            query_task = "/deployit/repository/query?parent=%s&type=udm.Application" % application_id
         query_task_response = self.http_request.get(query_task, contentType='application/xml')
         root = ET.fromstring(query_task_response.getResponse())
         items = root.findall('ci')
@@ -337,11 +339,11 @@ class XLDeployClient(object):
         if getChild:
             all_dir = self.get_all_directory(application_id)
             for curr_dir in all_dir:
-                all_package.extend(self.get_all_package_version(curr_dir, getChild, deploymentPackage))
+                all_package.extend(self.get_all_package_version(curr_dir, getChild, deploymentPackage, applicationPackage))
         return all_package
 
     def get_all_environment(self, environment_id, getChild):
-        query_task = "/deployit/repository/query?parent=%s&type=udm.Environment&resultsPerPage=-1" % environment_id
+        query_task = "/deployit/repository/query?parent=%s&type=udm.Environment" % environment_id
         query_task_response = self.http_request.get(query_task, contentType='application/xml')
         root = ET.fromstring(query_task_response.getResponse())
         items = root.findall('ci')

--- a/src/main/resources/xlr_xldeploy/XLDeployClient.py
+++ b/src/main/resources/xlr_xldeploy/XLDeployClient.py
@@ -338,8 +338,8 @@ class XLDeployClient(object):
             all_env.append(item.attrib['ref'])
         if getChild:
             all_dir = self.get_all_directory(environment_id)
-            for dir in all_dir:
-                all_env.extend(self.get_all_environment(dir, getChild))
+            for curr_dir in all_dir:
+                all_env.extend(self.get_all_environment(curr_dir, getChild))
         return all_env
 
     def get_latest_deployed_version(self, environment_id, application_name):

--- a/src/main/resources/xlr_xldeploy/XLDeployClient.py
+++ b/src/main/resources/xlr_xldeploy/XLDeployClient.py
@@ -308,6 +308,16 @@ class XLDeployClient(object):
             latest_package = items[-1].attrib['ref']
         return latest_package
 
+    def get_all_directory(self, directory_id):
+        query_task = "/deployit/repository/query?parent=%s&type=core.Directory&resultsPerPage=-1" % directory_id
+        query_task_response = self.http_request.get(query_task, contentType='application/xml')
+        root = ET.fromstring(query_task_response.getResponse())
+        items = root.findall('ci')
+        all_dir = list()
+        for item in items:
+            all_dir.append(item.attrib['ref'])
+        return all_dir
+
     def get_all_package_version(self, application_id):
         query_task = "/deployit/repository/query?parent=%s&resultsPerPage=-1" % application_id
         query_task_response = self.http_request.get(query_task, contentType='application/xml')
@@ -317,6 +327,20 @@ class XLDeployClient(object):
         for item in items:
             all_package.append(item.attrib['ref'])
         return all_package
+
+    def get_all_environment(self, environment_id, getChild):
+        query_task = "/deployit/repository/query?parent=%s&type=udm.Environment&resultsPerPage=-1" % environment_id
+        query_task_response = self.http_request.get(query_task, contentType='application/xml')
+        root = ET.fromstring(query_task_response.getResponse())
+        items = root.findall('ci')
+        all_env = list()
+        for item in items:
+            all_env.append(item.attrib['ref'])
+        if getChild:
+            all_dir = self.get_all_directory(environment_id)
+            for dir in all_dir:
+                all_env.extend(self.get_all_environment(dir, getChild))
+        return all_env
 
     def get_latest_deployed_version(self, environment_id, application_name):
         query_task_response = self.get_ci("%s/%s" % (environment_id, application_name), 'xml')

--- a/src/main/resources/xlr_xldeploy/getAllEnvsTask.py
+++ b/src/main/resources/xlr_xldeploy/getAllEnvsTask.py
@@ -15,7 +15,7 @@ xld_client = XLDeployClientUtil.create_xldeploy_client(xldeployServer, username,
 try:
     response = xld_client.check_ci_exist(environmentId)
 except:
-	response = False
+    response = False
 
 if throwOnFail and not response:
 	raise Exception(environmentId + " does not exist")

--- a/src/main/resources/xlr_xldeploy/getAllEnvsTask.py
+++ b/src/main/resources/xlr_xldeploy/getAllEnvsTask.py
@@ -1,0 +1,30 @@
+#
+# Copyright 2018 XEBIALABS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from xlr_xldeploy.XLDeployClientUtil import XLDeployClientUtil
+
+xld_client = XLDeployClientUtil.create_xldeploy_client(xldeployServer, username, password)
+
+try:
+    response = xld_client.check_ci_exist(environmentId)
+except:
+	response = False
+
+if throwOnFail and not response:
+	raise Exception(environmentId + " does not exist")
+
+environmentIds = xld_client.get_all_environment(environmentId, getChild)
+environmentIds.sort()
+
+if stripEnvironments:
+    environmentIds = [version.partition('/')[2] for version in environmentIds]
+
+if throwOnFail and len(environmentIds) == 0:
+	raise Exception(environmentId + " exists but has no versions")

--- a/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
@@ -20,7 +20,7 @@ except:
 if throwOnFail and not response:
 	raise Exception(applicationId + " does not exist")
 
-packageIds = xld_client.get_all_package_version(applicationId)
+packageIds = xld_client.get_all_package_version(applicationId, getChild, deploymentPackage)
 
 if stripApplications:
     packageIds = [version.partition('/')[2] for version in packageIds]

--- a/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
+++ b/src/main/resources/xlr_xldeploy/getAllVersionsTask.py
@@ -20,7 +20,7 @@ except:
 if throwOnFail and not response:
 	raise Exception(applicationId + " does not exist")
 
-packageIds = xld_client.get_all_package_version(applicationId, getChild, deploymentPackage)
+packageIds = xld_client.get_all_package_version(applicationId, getChild, deploymentPackage, applicationPackage)
 
 if stripApplications:
     packageIds = [version.partition('/')[2] for version in packageIds]


### PR DESCRIPTION
Take a path as input, and return all XLD environments available in this path (ex : Environments/MyEnvsFolder/)
The "Get Child" checkbox will allow to search for environments recursively in that path
The "Strip Environments" checkbox will cut the "Environments/" string in the paths returned, so that you are able to directly use one of the path returned as an input to a XLD deploy task.